### PR TITLE
Use pname+version attributes instead of name in wlroots

### DIFF
--- a/pkgs/wlroots/default.nix
+++ b/pkgs/wlroots/default.nix
@@ -14,7 +14,7 @@ let
   pname = "wlroots";
   version = metadata.rev;
 in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "swaywm";


### PR DESCRIPTION
The tinywl package in nixpkgs [uses the wlroot package’s version attribute directly](https://github.com/NixOS/nixpkgs/blob/586a9e6bffb1b4e0e444bf4013169d8f415f2987/pkgs/applications/window-managers/tinywl/default.nix#L7).