### PR TITLE
Use real package names instead of aliases from nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
         import pkgs {
           inherit system overlays;
           config.allowUnfree = true;
+          config.allowAliases = false;
         };
       pkgs_ = genAttrs (builtins.attrNames inputs) (inp: genAttrs supportedSystems (sys: pkgsFor inputs."${inp}" sys []));
       opkgs_ = overlays: genAttrs (builtins.attrNames inputs) (inp: genAttrs supportedSystems (sys: pkgsFor inputs."${inp}" sys overlays));

--- a/pkgs/aml/default.nix
+++ b/pkgs/aml/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, pkgconfig, meson, ninja
+, pkg-config, meson, ninja
 , wayland, wayland-protocols
 , libxkbcommon, libvncserver
 , libpthreadstubs, libdrm
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon libvncserver

--- a/pkgs/cage/default.nix
+++ b/pkgs/cage/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch
-, pkgconfig, meson, ninja, scdoc
+, pkg-config, meson, ninja, scdoc
 , wayland, wayland-protocols
-, wlroots, pixman, libxkbcommon, libudev, libGL, libX11
+, wlroots, pixman, libxkbcommon, udev, libGL, libX11
 }:
 
 let
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
     scdoc
     wayland wayland-protocols
-    wlroots pixman libxkbcommon libudev libGL libX11
+    wlroots pixman libxkbcommon udev libGL libX11
   ];
   mesonFlags = [ "-Dxwayland=true" ];
 

--- a/pkgs/drm_info/default.nix
+++ b/pkgs/drm_info/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub
 , libdrm, json_c
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , libpciaccess
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [ libdrm json_c libpciaccess ];
 
   mesonFlags = [ "-Dlibpci=disabled" ];

--- a/pkgs/gebaar-libinput/default.nix
+++ b/pkgs/gebaar-libinput/default.nix
@@ -1,5 +1,5 @@
 { gcc8Stdenv, lib, fetchFromGitHub
-, pkgconfig, cmake
+, pkg-config, cmake
 , libinput, zlib
 }:
 
@@ -19,7 +19,7 @@ gcc8Stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ pkgconfig cmake ];
+  nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [
     libinput zlib #cpptoml
   ];

--- a/pkgs/glpaper/default.nix
+++ b/pkgs/glpaper/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchhg
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wlroots, wayland, wayland-protocols
 , pixman, libxkbcommon
-, libudev, mesa_noglu, libX11
+, udev, mesa, libX11
 , libGL, libglvnd
 }:
 
@@ -19,10 +19,10 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [
     wlroots wayland wayland-protocols wlroots
-    pixman libxkbcommon libudev mesa_noglu libX11
+    pixman libxkbcommon udev mesa libX11
     libGL libglvnd
   ];
 

--- a/pkgs/grim/default.nix
+++ b/pkgs/grim/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , cairo, libjpeg, wayland, wayland-protocols
 , scdoc, buildDocs ? true
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja ] ++ lib.optional buildDocs scdoc;
   buildInputs = [ cairo libjpeg wayland wayland-protocols ];
   mesonFlags = [ "-Djpeg=enabled" ]
     ++ lib.optional buildDocs "-Dman-pages=enabled";

--- a/pkgs/gtk-layer-shell/default.nix
+++ b/pkgs/gtk-layer-shell/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig, scdoc
+, meson, ninja, pkg-config, scdoc
 , wayland, libinput, gtk3, gobject-introspection
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  nativeBuildInputs = [ meson ninja pkg-config scdoc ];
   buildInputs = [
     wayland libinput gtk3 gobject-introspection
   ];

--- a/pkgs/kanshi/default.nix
+++ b/pkgs/kanshi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
-, libudev, wayland, wayland-protocols
+, meson, ninja, pkg-config
+, udev, wayland, wayland-protocols
 , scdoc, buildDocs ? true
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja scdoc ];
+  nativeBuildInputs = [ pkg-config meson ninja scdoc ];
 
   buildInputs = [
     wayland wayland-protocols

--- a/pkgs/lavalauncher/default.nix
+++ b/pkgs/lavalauncher/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit
-, pkgconfig, meson, ninja, scdoc
+, pkg-config, meson, ninja, scdoc
 , wayland, wayland-protocols
 , libxkbcommon, cairo, librsvg
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja scdoc ];
+  nativeBuildInputs = [ pkg-config meson ninja scdoc ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon cairo librsvg

--- a/pkgs/mako/default.nix
+++ b/pkgs/mako/default.nix
@@ -1,5 +1,5 @@
 {stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , gtk3, cairo, pango, systemd
 , wayland, wayland-protocols
 , scdoc, buildDocs ? true
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja wrapGAppsHook ] ++ lib.optional buildDocs scdoc;
   buildInputs = [ gtk3 cairo pango systemd wayland wayland-protocols ];
   mesonFlags = [
     "-Dauto_features=enabled"

--- a/pkgs/neatvnc/default.nix
+++ b/pkgs/neatvnc/default.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, fetchFromGitHub
-, pkgconfig, meson, ninja
+, pkg-config, meson, ninja
 , wayland, wayland-protocols
 , libxkbcommon, libvncserver
 , libpthreadstubs, libdrm
 , pixman, libuv, libglvnd
-, gnutls, mesa_noglu
+, gnutls, mesa
 , aml, libjpeg_turbo
 }:
 
@@ -22,13 +22,13 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon libvncserver
     libpthreadstubs libdrm
     pixman libuv libglvnd
-    gnutls mesa_noglu
+    gnutls mesa
     aml libjpeg_turbo
   ];
 

--- a/pkgs/nwg-launchers/default.nix
+++ b/pkgs/nwg-launchers/default.nix
@@ -1,5 +1,5 @@
 {stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , gtk3, gtkmm3, epoxy, nlohmann_json
 , gtk-layer-shell, librsvg
 , wayland, wayland-protocols
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig meson ninja
+    pkg-config meson ninja
   ];
 
   buildInputs = [

--- a/pkgs/obs-studio/default.nix
+++ b/pkgs/obs-studio/default.nix
@@ -20,7 +20,7 @@
 , curl
 , xorg
 , makeWrapper
-, pkgconfig
+, pkg-config
 , vlc
 , mbedtls
 
@@ -30,7 +30,7 @@
 , python3
 
 , alsaSupport ? stdenv.isLinux
-, alsaLib
+, alsa-lib
 , pulseaudioSupport ? config.pulseaudio or stdenv.isLinux
 , pipewire
 , libpulseaudio
@@ -49,7 +49,7 @@ in mkDerivation rec {
     inherit (metadata) rev sha256;
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [ curl
                   fdk_aac
@@ -71,7 +71,7 @@ in mkDerivation rec {
                   qtwayland wayland
                 ]
                 ++ optionals scriptingSupport [ luajit swig python3 ]
-                ++ optional alsaSupport alsaLib
+                ++ optional alsaSupport alsa-lib
                 ++ optional pulseaudioSupport libpulseaudio
                 ++ [ pipewire ];
 

--- a/pkgs/obs-studio/wlrobs.nix
+++ b/pkgs/obs-studio/wlrobs.nix
@@ -6,7 +6,7 @@
 # mkdir -p ~/.config/obs-studio/plugins/wlrobs/bin/64bit
 # ln -s ~/.nix-profile/share/obs/obs-plugins/wlrobs/bin/64bit/libwlrobs.so ~/.config/obs-studio/plugins/wlrobs/bin/64bit
 { stdenv, lib, fetchhg, wayland, obs-studio
-, meson, ninja, pkgconfig, libX11
+, meson, ninja, pkg-config, libX11
 , dmabufSupport ? false, libdrm ? null, libGL ? null}:
 
 assert dmabufSupport -> libdrm != null && libGL != null;
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     sha256 = "0j01wkhwhhla4qx8mwyrq2qj9cfhxksxaq2k8rskmy2qbdkvvdpb";
   };
 
-  buildInputs = [ libX11 libGL libdrm meson ninja pkgconfig wayland obs-studio ];
+  buildInputs = [ libX11 libGL libdrm meson ninja pkg-config wayland obs-studio ];
 
   installPhase = ''
     mkdir -p $out/share/obs/obs-plugins/wlrobs/bin/64bit

--- a/pkgs/oguri/default.nix
+++ b/pkgs/oguri/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
-, cairo, gdk_pixbuf, wayland, wayland-protocols
+, meson, ninja, pkg-config
+, cairo, gdk-pixbuf, wayland, wayland-protocols
 }:
 
 let
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
-  buildInputs = [ cairo gdk_pixbuf wayland wayland-protocols ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [ cairo gdk-pixbuf wayland wayland-protocols ];
   mesonFlags = [ "-Dauto_features=enabled" ];
 
   enableParallelBuilding = true;

--- a/pkgs/rootbar/default.nix
+++ b/pkgs/rootbar/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchhg
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wayland, wayland-protocols
 , gtk3, json_c, libpulseaudio
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig
+    meson ninja pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/sirula/default.nix
+++ b/pkgs/sirula/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, pkgconfig, glib, cairo, pango, atk
+{ stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config, glib, cairo, pango, atk
 , gdk-pixbuf, gtk3, gtk-layer-shell }:
 
 let
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = metadata.cargoSha256;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ glib cairo pango atk gdk-pixbuf gtk3 gtk-layer-shell ];
 
   meta = with lib; {

--- a/pkgs/slurp/default.nix
+++ b/pkgs/slurp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , cairo, wayland, wayland-protocols
 , scdoc, buildDocs ? true
 , libxkbcommon
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja ] ++ lib.optional buildDocs scdoc;
   buildInputs = [
     cairo wayland wayland-protocols
     libxkbcommon

--- a/pkgs/swaybg/default.nix
+++ b/pkgs/swaybg/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , cairo, wayland, wayland-protocols
-, gdk_pixbuf, nonPngSupport ? true
+, gdk-pixbuf, nonPngSupport ? true
 , scdoc, buildDocs ? true
 }:
 
@@ -23,9 +23,9 @@ stdenv.mkDerivation rec {
     sed -iE "0,/version: '.*',/ s//version: '${version}',/" meson.build
   '';
 
-  nativeBuildInputs = [ pkgconfig meson ninja ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja ] ++ lib.optional buildDocs scdoc;
 
-  buildInputs = [ cairo wayland wayland-protocols ] ++ lib.optional nonPngSupport gdk_pixbuf;
+  buildInputs = [ cairo wayland wayland-protocols ] ++ lib.optional nonPngSupport gdk-pixbuf;
 
   mesonFlags = lib.optional nonPngSupport "-Dgdk-pixbuf=enabled"
     ++ lib.optional buildDocs "-Dman-pages=enabled";

--- a/pkgs/swayidle/default.nix
+++ b/pkgs/swayidle/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub
 , meson, ninja
-, pkgconfig, scdoc
+, pkg-config, scdoc
 , wayland, wayland-protocols
 , systemd
 , buildDocs ? true
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    pkgconfig meson ninja
+    pkg-config meson ninja
   ] ++ lib.optional buildDocs scdoc;
 
   buildInputs = [

--- a/pkgs/swaylock/default.nix
+++ b/pkgs/swaylock/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchFromGitHub
 , meson, ninja
-, pkgconfig, scdoc
+, pkg-config, scdoc
 , wayland, wayland-protocols
-, libxkbcommon, cairo, pango, gdk_pixbuf, pam
+, libxkbcommon, cairo, pango, gdk-pixbuf, pam
 , buildDocs ? true
 }:
 
@@ -26,12 +26,12 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    pkgconfig meson ninja
+    pkg-config meson ninja
   ] ++ lib.optional buildDocs scdoc;
 
   buildInputs = [
     wayland wayland-protocols
-    libxkbcommon cairo pango gdk_pixbuf pam
+    libxkbcommon cairo pango gdk-pixbuf pam
   ];
 
   mesonFlags = [

--- a/pkgs/wayfire/default.nix
+++ b/pkgs/wayfire/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, pkgconfig, ninja, cmake
+, meson, pkg-config, ninja, cmake
 , wayland, wayland-protocols
 , cairo, glm
 , libevdev, freetype, libinput
@@ -8,7 +8,7 @@
 , libGL, mesa
 , libcap, xcbutilerrors, xcbutilwm, libxml2
 , libuuid
-, libseat, xorg, xwayland, doctest
+, seatd, xorg, xwayland, doctest
 , pango
 , vulkan-headers, vulkan-loader, glslang
 , buildDocs ? true
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig meson ninja cmake
+    pkg-config meson ninja cmake
     doctest
   ];
   buildInputs = [
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     libGL mesa
     libcap xcbutilerrors xcbutilwm libxml2
     libuuid
-    libseat
+    seatd
     xwayland
     doctest
     xorg.xcbutilrenderutil
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     "-Duse_system_wlroots=disabled"
     "-Duse_system_wfconfig=disabled"
     "-Dwlroots:logind-provider=systemd"
-    "-Dwlroots:libseat=disabled"
+    "-Dwlroots:seatd=disabled"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/waypipe/default.nix
+++ b/pkgs/waypipe/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchgit
-, meson, ninja, pkgconfig, python3
+, meson, ninja, pkg-config, python3
 , wayland, wayland-protocols
-, libffi, mesa_noglu
+, libffi, mesa
 , lz4, zstd, ffmpeg_4, libva
 , scdoc, openssh
 }:
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
       --replace "/usr/bin/ssh" "${openssh}/bin/ssh"
   '';
 
-  nativeBuildInputs = [ pkgconfig meson ninja python3 scdoc ];
+  nativeBuildInputs = [ pkg-config meson ninja python3 scdoc ];
   buildInputs = [
     wayland wayland-protocols
-    libffi mesa_noglu
+    libffi mesa
     lz4 zstd ffmpeg_4 libva
   ];
   mesonFlags = [ "-Dauto_features=enabled" ];

--- a/pkgs/wayvnc/default.nix
+++ b/pkgs/wayvnc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, pkgconfig, meson, ninja
+, pkg-config, meson, ninja
 , wayland, wayland-protocols
 , libxkbcommon, libvncserver
 , libpthreadstubs
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon libvncserver

--- a/pkgs/wdisplays/default.nix
+++ b/pkgs/wdisplays/default.nix
@@ -1,5 +1,5 @@
 {stdenv, lib, fetchFromGitHub, fetchpatch
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , gtk3, epoxy
 , wayland, wayland-protocols
 , scdoc, buildDocs ? true
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja ] ++ lib.optional buildDocs scdoc;
   buildInputs = [ gtk3 epoxy wayland wayland-protocols ];
   mesonFlags = [ "-Dauto_features=enabled" ]
     ++ lib.optional (!buildDocs) "-Dman-pages=disabled";

--- a/pkgs/wev/default.nix
+++ b/pkgs/wev/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit
-, pkgconfig, scdoc
+, pkg-config, scdoc
 , wayland, wayland-protocols
 , libxkbcommon
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig scdoc ];
+  nativeBuildInputs = [ pkg-config scdoc ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon

--- a/pkgs/wf-recorder/default.nix
+++ b/pkgs/wf-recorder/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wayland, wayland-protocols
 , ffmpeg, x264, libpulseaudio
 , scdoc, opencl-headers, ocl-icd
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     inherit (metadata) rev sha256;
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  nativeBuildInputs = [ meson ninja pkg-config scdoc ];
   buildInputs = [ wayland wayland-protocols ffmpeg x264 libpulseaudio opencl-headers ocl-icd ];
 
   meta = with lib; {

--- a/pkgs/wl-clipboard/default.nix
+++ b/pkgs/wl-clipboard/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wayland, wayland-protocols
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [ wayland wayland-protocols ];
   mesonFlags = [ "-Dfishcompletiondir=no"];
 

--- a/pkgs/wl-gammactl/default.nix
+++ b/pkgs/wl-gammactl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wayland, wayland-protocols
 , gtk3, wlroots
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [
     gtk3 wlroots
     wayland wayland-protocols

--- a/pkgs/wlay/default.nix
+++ b/pkgs/wlay/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, cmake, extra-cmake-modules, pkgconfig
+, cmake, extra-cmake-modules, pkg-config
 , wayland, wayland-protocols
 , epoxy, libpthreadstubs
 , libGL, glfw3
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig cmake extra-cmake-modules ];
+  nativeBuildInputs = [ pkg-config cmake extra-cmake-modules ];
   buildInputs = [
     wayland wayland-protocols
     epoxy libpthreadstubs

--- a/pkgs/wldash/default.nix
+++ b/pkgs/wldash/default.nix
@@ -1,6 +1,6 @@
 { lib, rustPlatform, fetchFromGitHub
-, pkgconfig
-, dbus, libpulseaudio, alsaLib, libxkbcommon
+, pkg-config
+, dbus, libpulseaudio, alsa-lib, libxkbcommon
 , wayland, fontconfig
 }:
 
@@ -21,9 +21,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = metadata.cargoSha256;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ dbus libpulseaudio alsaLib fontconfig ];
+  buildInputs = [ dbus libpulseaudio alsa-lib fontconfig ];
 
   dontPatchELF = true;
   

--- a/pkgs/wlfreerdp/default.nix
+++ b/pkgs/wlfreerdp/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
-, alsaLib, ffmpeg, glib, openssl, pcre, zlib
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config
+, alsa-lib, ffmpeg, glib, openssl, pcre, zlib
 , libX11, libXcursor, libXdamage, libXext, libXi, libXinerama, libXrandr, libXrender, libXv
 , libxkbcommon, libxkbfile
 , libusb1
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = with lib; [
-    alsaLib cups ffmpeg glib openssl pcre pcsclite libpulseaudio zlib
+    alsa-lib cups ffmpeg glib openssl pcre pcsclite libpulseaudio zlib
     gstreamer gst-plugins-base gst-plugins-good libunwind orc
     libX11 libXcursor libXdamage libXext libXi libXinerama libXrandr libXrender libXv
     libxkbcommon libxkbfile
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   ] ++ optional stdenv.isLinux systemd;
 
   nativeBuildInputs = [
-    cmake pkgconfig
+    cmake pkg-config
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/wlr-randr/default.nix
+++ b/pkgs/wlr-randr/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wayland, wayland-protocols
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     inherit (metadata) rev sha256;
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [
     wayland wayland-protocols
   ];

--- a/pkgs/wlroots/default.nix
+++ b/pkgs/wlroots/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchFromGitLab, fetchpatch, meson, ninja, pkgconfig
+{ stdenv, lib, fetchFromGitLab, fetchpatch, meson, ninja, pkg-config
 , wayland, wayland-protocols, libinput, libxkbcommon, pixman
-, xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa_noglu
+, xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
 , libglvnd
 , libpng, ffmpeg_4
-, libseat
+, seatd
 , libuuid
 , xorg # ?
 , enableXWayland ? true, xwayland ? null
@@ -29,14 +29,14 @@ in stdenv.mkDerivation rec {
   # programs (in examples) AND rootston
   outputs = [ "out" "examples" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig xwayland ];
+  nativeBuildInputs = [ meson ninja pkg-config xwayland ];
 
   buildInputs = [
     wayland wayland-protocols libinput libxkbcommon pixman
-    xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa_noglu
+    xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
     libpng ffmpeg_4
     libglvnd
-    libseat
+    seatd
     libuuid
     xorg.xcbutilrenderutil
     vulkan-headers vulkan-loader glslang

--- a/pkgs/wlsunset/default.nix
+++ b/pkgs/wlsunset/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , cairo, libjpeg, wayland, wayland-protocols
 , scdoc, buildDocs ? true
 }:
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja ] ++ lib.optional buildDocs scdoc;
   buildInputs = [ cairo libjpeg wayland wayland-protocols ];
 
   enableParallelBuilding = true;

--- a/pkgs/wlvncc/default.nix
+++ b/pkgs/wlvncc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, pkgconfig, meson, ninja
+, pkg-config, meson, ninja
 , wayland, wayland-protocols
 , libxkbcommon, libvncserver
 , libpthreadstubs
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon libvncserver

--- a/pkgs/wofi/default.nix
+++ b/pkgs/wofi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchhg
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , wayland, wayland-protocols
 , gtk3
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    meson ninja pkgconfig
+    meson ninja pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/wshowkeys/default.nix
+++ b/pkgs/wshowkeys/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, meson, ninja, pkgconfig
+, meson, ninja, pkg-config
 , pango, libinput, libxkbcommon, wayland, wayland-protocols
 , scdoc, buildDocs ? true
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ] ++ lib.optional buildDocs scdoc;
+  nativeBuildInputs = [ pkg-config meson ninja ] ++ lib.optional buildDocs scdoc;
   buildInputs = [ pango wayland wayland-protocols libinput libxkbcommon ];
   mesonFlags = [
     "-Dauto_features=enabled"

--- a/pkgs/wtype/default.nix
+++ b/pkgs/wtype/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, pkgconfig, meson, ninja
+, pkg-config, meson, ninja
 , wayland, wayland-protocols
 , libxkbcommon
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sha256 = metadata.sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
     wayland wayland-protocols
     libxkbcommon


### PR DESCRIPTION
This makes it possible to use the overlay on NixOS systems where `nixpkgs.config.allowAliases = false`.