### PR TITLE
foot(fix): use wayland master branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,11 @@
               meson = _mesonNewer;
             };
             drm_info         = prev.callPackage ./pkgs/drm_info {};
-            foot             = prev.callPackage ./pkgs/foot { inherit foot; };
+            foot             = prev.callPackage ./pkgs/foot {
+              inherit foot;
+              wayland = _waylandNewer;
+              wayland-protocols =_wayland-protocols-master;
+            };
             gebaar-libinput  = prev.callPackage ./pkgs/gebaar-libinput {};
             glpaper          = prev.callPackage ./pkgs/glpaper {};
             grim             = prev.callPackage ./pkgs/grim {};


### PR DESCRIPTION
Due to the core wayland protocols getting an update, foot will crash on sway's master branch with the following messages:
```
interface 'wl_output' has no event 4
 err: wayland.c:1307: compositor does not support ARGB surfaces
 err: wayland.c:1660: failed to flush wayland socket: Bad address
```