### PR TITLE
i3status-rust: update cargo vendor hash as well

### DIFF
--- a/pkgs/i3status-rust/metadata.nix
+++ b/pkgs/i3status-rust/metadata.nix
@@ -2,6 +2,6 @@
   repo_git = "https://github.com/greshake/i3status-rust";
   branch = "master";
   rev = "87e9c2ef53f8b878813ec228b35b70fb224fc29d";
-  sha256 = "sha256-AaPPxKxKAHlsxEBpIXYz10s+qjpj1TOfsRIh5j3pp7A=";
-  cargoSha256 = "sha256-ztjVmpytvRyPkws3PGX2BehOGa2//9xSS8rEOajepR0=";
+  sha256 = "AaPPxKxKAHlsxEBpIXYz10s+qjpj1TOfsRIh5j3pp7A=";
+  cargoSha256 = "3/v9E63EPQl3LA2l/YHLx+KdiLYRBfFGC+bags1VhlQ=";
 }


### PR DESCRIPTION
The latest manual autoupdate in f9d20aea did not update the vendor hash, this PR fixes that.

Mentioning @colemickens because his bot authored the breaking commit.