### PR TITLE
i3status-rust: update the cargoSha256

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643524588,
-        "narHash": "sha256-Qh5AazxdOQRORbGkkvpKoovDl6ej/4PhDabFsqnueqw=",
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "efeefb2af1469a5d1f0ae7ca8f0dfd9bb87d5cfb",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
         "type": "github"
       },
       "original": {

--- a/pkgs/i3status-rust/metadata.nix
+++ b/pkgs/i3status-rust/metadata.nix
@@ -3,5 +3,5 @@
   branch = "master";
   rev = "a5c1bc6d95594841e0e5ad5a2ffc97a214df0427";
   sha256 = "sha256-eVu2sEV1RHoXkY4eSQnIB1kj1WBW8azN+0t2MFI557o=";
-  cargoSha256 = "sha256-KIU0YWxlYL5GVOVAQZddg3PvE3qCnlukPmWgAU9sCO0=";
+  cargoSha256 = "sha256-tNwf2ShnzoSrb1R/g0hOGwQMulWYXyVCILU3Jb+Sfpg=";
 }


### PR DESCRIPTION
Fixes this error;
```
error: hash mismatch in fixed-output derivation '/nix/store/pd3dc7kpw3wwzwans41lqpjaf999xxx1-i3status-rust-0.21.4-vendor.tar.gz.drv':
         specified: sha256-KIU0YWxlYL5GVOVAQZddg3PvE3qCnlukPmWgAU9sCO0=
            got:    sha256-tNwf2ShnzoSrb1R/g0hOGwQMulWYXyVCILU3Jb+Sfpg=
```