### PR TITLE
i3status-rust: update the cargoSha256

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644613700,
-        "narHash": "sha256-wLRPJclMH8vsHuFtyI78aF09lw5mbi3lMB6uiK5S2wE=",
+        "lastModified": 1645334861,
+        "narHash": "sha256-We9ECiMglthzbZ5S6Myqqf+RHzBFZPoM2qL5/jDkUjs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23d785aa6f853e6cf3430119811c334025bbef55",
+        "rev": "d5f237872975e6fb6f76eef1368b5634ffcd266f",
         "type": "github"
       },
       "original": {

--- a/pkgs/i3status-rust/metadata.nix
+++ b/pkgs/i3status-rust/metadata.nix
@@ -3,5 +3,5 @@
   branch = "master";
   rev = "e9ead0a5855bd7046bfb65964b64b7918a249f7d";
   sha256 = "sha256-FM5KxjNrSAwRn2vS+8p+TLxcbY9j8OSkLuLFG53WTY4=";
-  cargoSha256 = "sha256-Ne6vEqboJ/Cak0XVWB+ZM3fnqwF+g0qDhkn00KSOxco=";
+  cargoSha256 = "sha256-r3QviQIWeoh+G8nvfIbWbNRRXt0mfqReJhx7FC0bqLI=";
 }


### PR DESCRIPTION
Fixes:
```
building the system configuration...
error: hash mismatch in fixed-output derivation '/nix/store/s3m2ksdlgrdn9yn7fgfi7h5wk9mn42q7-i3status-rust-0.21.5-vendor.tar.gz.drv':
         specified: sha256-Ne6vEqboJ/Cak0XVWB+ZM3fnqwF+g0qDhkn00KSOxco=
            got:    sha256-r3QviQIWeoh+G8nvfIbWbNRRXt0mfqReJhx7FC0bqLI=
```