### PR TITLE
template.nix: change version format to `+${substring 0 7 metadata.rev}`

### DIFF
--- a/templates/template.nix
+++ b/templates/template.nix
@@ -57,7 +57,7 @@ in
 overridenAttr.overrideAttrs (oldAttrs: (
   {
     pname = attrName;
-    version = metadata.rev;
+    version = "+${lib.substring 0 7 metadata.rev}";
     inherit src;
   } // lib.optionalAttrs (extra ? nativeBuildInputs)
     {


### PR DESCRIPTION
format is similar to RFC https://github.com/NixOS/rfcs/pull/107

+g is not used because we also have hg sources

fixes https://github.com/nix-community/nixpkgs-wayland/issues/282 (though i couldn't replicate the issue (but it still fixes builtins.parseDrvName))