### PR TITLE
swww: init at 0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ nix-env -iA neatvnc
 | [neatvnc](https://github.com/any1/neatvnc) | A VNC server library |
 | [new-wayland-protocols](https://gitlab.freedesktop.org/wayland/wayland-protocols/) | Wayland protocol extensions |
 | [obs-wlrobs](https://hg.sr.ht/~scoopta/wlrobs) | An obs-studio plugin that allows you to screen capture on wlroots based wayland compositors |
-| [oguri](https://github.com/vilhalmer/oguri) | A very nice animated wallpaper daemon for Wayland compositors |
 | [rootbar](https://hg.sr.ht/~scoopta/rootbar) | A bar for Wayland WMs |
 | [salut](https://gitlab.com/snakedye/salut) | A sleek notification daemon |
 | [shotman](https://git.sr.ht/~whynothugo/shotman) | Uncompromising screenshot GUI for Wayland |
@@ -224,6 +223,7 @@ nix-env -iA neatvnc
 | [swayidle](https://github.com/swaywm/swayidle) | Idle management daemon for Wayland |
 | [swaylock](https://github.com/swaywm/swaylock) | Screen locker for Wayland |
 | [swaylock-effects](https://github.com/mortie/swaylock-effects) | Screen locker for Wayland |
+| [swww](https://github.com/Horus645/swww) | A Solution to your Wayland Wallpaper Woes |
 | [waybar](https://github.com/Alexays/Waybar) | Highly customizable Wayland bar for Sway and Wlroots based compositors |
 | [wayfire-unstable](https://wayfire.org/) | 3D wayland compositor |
 | [waypipe](https://gitlab.freedesktop.org/mstoeckl/waypipe/) | A network proxy for Wayland clients (applications) |

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,6 @@
             "imv"
             "mako"
             "neatvnc"
-            "oguri"
             "slurp"
             "swaybg"
             "swayidle"
@@ -141,6 +140,7 @@
           waylandPkgs = genPackagesGH // rec {
             # wlroots-related
             salut = prev.callPackage ./pkgs/salut { };
+            swww = prev.callPackage ./pkgs/swww { };
             wayprompt = prev.callPackage ./pkgs/wayprompt { };
             wlvncc = prev.callPackage ./pkgs/wlvncc {
               libvncserver = final.libvncserver_master;

--- a/pkgs/oguri/metadata.nix
+++ b/pkgs/oguri/metadata.nix
@@ -1,9 +1,0 @@
-rec {
-  domain = "github.com";
-  owner = "vilhalmer";
-  repo = "oguri";
-  repo_git = "https://${domain}/${owner}/${repo}";
-  branch = "master";
-  rev = "8b47791bad00f5acef48f87f34d7ca349ce70cff";
-  sha256 = "sha256-jgnFZkt0cga3Xz9DKWnV/x5C9+QrnIrbZ9D5KCf5IcM=";
-}

--- a/pkgs/swww/default.nix
+++ b/pkgs/swww/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, libxkbcommon
+}:
+
+let
+  metadata = import ./metadata.nix;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "swww";
+  version = metadata.rev;
+
+  src = fetchFromGitHub {
+    inherit (metadata) owner repo rev sha256;
+  };
+
+  inherit (metadata) cargoSha256;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxkbcommon
+  ];
+
+  # FIXME: The tests rely on a running wayland environment
+  #        providing a socket. Not sure how to address this
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Solution to your Wayland Wallpaper Woes";
+    homepage = "https://github.com/Horus645/swww";
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/swww/metadata.nix
+++ b/pkgs/swww/metadata.nix
@@ -1,0 +1,10 @@
+rec {
+  owner = "Horus645";
+  repo = "swww";
+  repo_git = "https://github.com/${owner}/${repo}";
+  branch = "main";
+  skip = true;
+  rev = "25f0e8edaeeb8886b23ef9db81bb48c9efc22d86";
+  sha256 = "sha256-Z90Zwjqcu0hbtJwKPUNV996mtdgX//ZWWm+Dya/JV9A=";
+  cargoSha256 = "sha256-NbQJAohjQQcbcmxgekbdbufybHzs1RRdCiGq0npPjCE=";
+}


### PR DESCRIPTION
These changes replace oguri with swww, as oguri is no longer maintained.

Fixes #389

As noted in the package definition, swww has tests that rely on a wayland env and attempts to connect to the socket.  
To get a successful build I set `doCheck = false` for now. Is there a common convention for this case?