### PR TITLE
Revert "waybar fix build"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,9 +62,6 @@
                 prev.libjack2
                 prev.playerctl
               ];
-              replaceInput = {
-                spdlog = prev.spdlog.override { fmt = prev.fmt_9; };
-              };
               replace.postUnpack =
                 let
                   # Derived from subprojects/cava.wrap


### PR DESCRIPTION
This reverts commit 30ddf7595b1e4f063e892ddd886596bc346c4f85.

nixpkgs spdlog uses spdlog_9 as its input now.

See https://github.com/NixOS/nixpkgs/commit/48c25dcaf2deb249615707a310af23ccb42b04c3
