### PR TITLE
wl-screenrec: init at unstable-2023-09-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ nix-env -iA neatvnc
 | [wl-clipboard](https://github.com/bugaevc/wl-clipboard) | Command-line copy/paste utilities for Wayland |
 | [wl-gammactl](https://github.com/mischw/wl-gammactl) | Contrast, brightness, and gamma adjustments for Wayland |
 | [wl-gammarelay-rs](https://github.com/MaxVerevkin/wl-gammarelay-rs) | A simple program that provides DBus interface to control display temperature and brightness under wayland without flickering  |
+| [wl-screenrec](https://github.com/russelltg/wl-screenrec) | High performance wlroots screen recording, featuring hardware encoding |
 | [wlay](https://github.com/atx/wlay) | Graphical output management for Wayland |
 | [wldash](https://wldash.org) | Wayland launcher/dashboard |
 | [wlogout](https://github.com/ArtsyMacaw/wlogout) | A wayland based logout menu |

--- a/flake.nix
+++ b/flake.nix
@@ -211,6 +211,8 @@
 
             wl-gammarelay-rs = prev.callPackage ./pkgs/wl-gammarelay-rs { };
 
+            wl-screenrec = prev.callPackage ./pkgs/wl-screenrec { };
+
             freerdp3 = prev.callPackage ./pkgs/freerdp3 {
               inherit (prev.darwin.apple_sdk.frameworks) AudioToolbox AVFoundation Carbon Cocoa CoreMedia;
               inherit (prev.gst_all_1) gstreamer gst-plugins-base gst-plugins-good;

--- a/pkgs/wl-screenrec/default.nix
+++ b/pkgs/wl-screenrec/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, ffmpeg
+, libdrm
+, wayland
+}:
+
+let
+  metadata = import ./metadata.nix;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "wl-screenrec";
+  version = metadata.rev;
+
+  src = fetchFromGitHub {
+    inherit (metadata) owner repo rev sha256;
+  };
+
+  cargoLock = {
+    lockFile = src + "/Cargo.lock";
+    allowBuiltinFetchGit = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    ffmpeg
+    libdrm
+    wayland
+  ];
+
+  doCheck = false; # tries to use host compositor, etc
+
+  meta = with lib; {
+    description = "High performance wlroots screen recording, featuring hardware encoding";
+    homepage = "https://github.com/russelltg/wl-screenrec";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    mainProgram = "wl-screenrec";
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/wl-screenrec/metadata.nix
+++ b/pkgs/wl-screenrec/metadata.nix
@@ -1,0 +1,9 @@
+rec {
+  domain = "github.com";
+  owner = "russelltg";
+  repo = "wl-screenrec";
+  repo_git = "https://${domain}/${owner}/${repo}";
+  branch = "main";
+  rev = "a36c5923009b44f2131196d8a3a234948f8e0102";
+  sha256 = "sha256-V29eB9vozVKIBq8dO7zgA4nirsh1eDBjJN+rwVkeDLE=";
+}


### PR DESCRIPTION
I just bumped this in `nixpkgs` and figured I'd add it here too.

I don't think we have an example of a rust package that just overrides the version from nixpkgs.

I don't fully grok what the huge difference is but the mechanism used here uses IFD for Cargo.lock vs in nixpkgs it's still using `cargoHash`.