### PR TITLE
template.nix: allow replace with oldAttrs param

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,15 +101,17 @@
                 wlroots = final.wlroots;
                 wayland-protocols = final.new-wayland-protocols;
               };
-              replace.patches =
-                let
-                  conflicting-patch = (prev.fetchpatch {
-                    name = "LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM.patch";
-                    url = "https://github.com/swaywm/sway/commit/dee032d0a0ecd958c902b88302dc59703d703c7f.diff";
-                    hash = "sha256-dx+7MpEiAkxTBnJcsT3/1BO8rYRfNLecXmpAvhqGMD0=";
-                  });
-                in
-                lib.remove conflicting-patch prev.sway-unwrapped.patches;
+              replace = oldAttrs: {
+                patches =
+                  let
+                    conflicting-patch = (prev.fetchpatch {
+                      name = "LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM.patch";
+                      url = "https://github.com/swaywm/sway/commit/dee032d0a0ecd958c902b88302dc59703d703c7f.diff";
+                      hash = "sha256-dx+7MpEiAkxTBnJcsT3/1BO8rYRfNLecXmpAvhqGMD0=";
+                    });
+                  in
+                  lib.remove conflicting-patch oldAttrs.patches;
+              };
             }
             {
               attrName = "cage";

--- a/templates/template.nix
+++ b/templates/template.nix
@@ -57,6 +57,11 @@ let
     allowBuiltinFetchGit = true;
   };
 
+  replace' = oldAttrs:
+    if builtins.isFunction replace then
+      replace oldAttrs
+    else
+      replace;
 
 in
 overridenAttr.overrideAttrs (oldAttrs: (
@@ -81,5 +86,5 @@ overridenAttr.overrideAttrs (oldAttrs: (
     {
       cargoDeps = prev.rustPlatform.importCargoLock cargoLock;
       cargoHash = null;
-    } // replace
+    } // replace' oldAttrs
 ))


### PR DESCRIPTION
Closes nix-community/nixpkgs-wayland#426

This allows our packages to replace attributes while still being able to access the original attributes.
Most notably, this allows us to use the final `oldAttrs` including all following `.override` calls.
