### PR TITLE
wlroots: exclude upstream backport patch

### DIFF
--- a/pkgs/wlroots/default.nix
+++ b/pkgs/wlroots/default.nix
@@ -3,6 +3,7 @@ args_@{ lib
 , wlroots
 , libdisplay-info
 , hwdata
+, fetchpatch
 , ...
 }:
 
@@ -17,4 +18,13 @@ in
   src = fetchFromGitLab {
     inherit (metadata) domain owner repo rev sha256;
   };
+  patches =
+    let
+      conflicting-patch = (fetchpatch {
+        name = "tinywl-fix-wlroots-dependency-constraint-in-Makefile.patch";
+        url = "https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/fe53ec693789afb44c899cad8c2df70c8f9f9023.patch";
+        hash = "sha256-wU62hXgmsAyT5j/bWeCFBkvM9cYjUntdCycQt5HAhb8=";
+      });
+    in
+    lib.remove conflicting-patch old.patches;
 })


### PR DESCRIPTION
Closes #434

See https://github.com/NixOS/nixpkgs/commit/3e1dba866f8346b38bc236483b1d80cee352be3d
