### PR TITLE
sway-unwrapped: wlroots_0_16 -> wlroots

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
               attrName = "sway-unwrapped";
               extra.buildInputs = [ prev.xorg.xcbutilwm ];
               replaceInput = {
-                wlroots_0_16 = final.wlroots;
+                wlroots = final.wlroots;
                 wayland-protocols = final.new-wayland-protocols;
               };
               replace = oldAttrs: {


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/36e51d7cbfc920f3e51a5b234f0f35c4b03c8ba7 changed the input name to wlroots, we are providing wlroots_0_16 still 