### PR TITLE
wlroots moved to alias in nixpkgs, use wlroots_0_18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -297,7 +297,7 @@
             # };
             wldash = prev.callPackage ./pkgs/wldash { };
             wlroots = prev.callPackage ./pkgs/wlroots {
-              inherit (prev) wlroots;
+              wlroots = prev.wlroots_0_18;
               wayland-protocols = final.new-wayland-protocols;
             };
 


### PR DESCRIPTION
"wlroots" was moved to aliases.nix in https://github.com/NixOS/nixpkgs/pull/252816. wlroots = wlroots_0_18 in aliases.nix, so I used that here.