### PR TITLE
manual "auto"-updates

### DIFF
--- a/pkgs/dunst/metadata.nix
+++ b/pkgs/dunst/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "dunst";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "b23a2d3a2eeecd1c6dbddf5ce2e70fcd40bdb53e";
-  sha256 = "sha256-WPFQ6cNsFYBB6kHdcYxY8QHF9AmJ18b3Meg0rx8LAis=";
+  rev = "844167abe1f7845bfe7c81797da36be28362e7b9";
+  sha256 = "sha256-9RnjiwQPt4cuc1uuKl+TFVagbB0sjqdnelOpD70LJHU=";
 }

--- a/pkgs/foot/metadata.nix
+++ b/pkgs/foot/metadata.nix
@@ -5,6 +5,6 @@ rec {
   repo = "foot";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "85b2fb1e32d499520e5c33f2357d58d35bcb0b60";
-  sha256 = "sha256-tEHSZPWJtyUSRdg9s1VLimUnXFzut6FfpmFQktdYR8A=";
+  rev = "62b0b65d4712abd9ecd21ec2fe684c87a868bcc1";
+  sha256 = "sha256-afcW0GhCYC4zuOMg4//RpnLAnSeZkDs4ssKd676BBWk=";
 }

--- a/pkgs/freerdp3/metadata.nix
+++ b/pkgs/freerdp3/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "FreeRDP";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "d91f90c7cccf9fb9c3e58be5d6ba45060a3630a2";
-  sha256 = "sha256-lK88fpopvs67zEO7jxhfBX6Tib6jBT6xIZhDTm/yopA=";
+  rev = "bf6f2b958306959be68d8b104cde0ddd9276da49";
+  sha256 = "sha256-ED1JLYNrgoD4mwwu4Gp+8+Ymwg91CYzA2YrDUK216yY=";
 }

--- a/pkgs/i3status-rust/metadata.nix
+++ b/pkgs/i3status-rust/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "i3status-rust";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "f895b129a9059750ea707c048a2f505093b3ccb1";
-  sha256 = "sha256-9e4WKuzWOU4Y0KHAM63COG8LrbK8DrTWSkbL4X1R+jw=";
+  rev = "8ea1a2a78128b670499dfc2bfc71ab8a4ad0481f";
+  sha256 = "sha256-xlyasx+zLcvhUOZt+xAbWFEGY0R+DDHF6+HftEXRcY8=";
 }

--- a/pkgs/neatvnc/metadata.nix
+++ b/pkgs/neatvnc/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "neatvnc";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "76ea172a78096ad74e03c7138ca4909c4894ae41";
-  sha256 = "sha256-NiM3J+B1ixf8C/145soy60XbLMeBt/9FprRC+RjuGcw=";
+  rev = "9fba40d7786b7695e715d1cf355dab2ce3fa8880";
+  sha256 = "sha256-PJWGLbt+bDUTp/bRyRqq0iRZkPe2qorXP/NC+1g6Dvg=";
 }

--- a/pkgs/shotman/metadata.nix
+++ b/pkgs/shotman/metadata.nix
@@ -5,6 +5,6 @@ rec {
   repo = "shotman";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "main";
-  rev = "c8bf05f09a3f65d6e72b2121198558210c948025";
-  sha256 = "sha256-Xmsl2k6+b7OSqXcRNLWolSj4stmEqm6Juzjw5lxZhYs=";
+  rev = "8a79f1501fa0cbc114a1a0e19d4118b20686d0a4";
+  sha256 = "sha256-kf/qloCaptxPzPEgd8fkzTfgqsI/PC3KJfHpBQWadjQ=";
 }

--- a/pkgs/slurp/metadata.nix
+++ b/pkgs/slurp/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "slurp";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "0616010cbc74e79368f75a220cc4eb7a6116dcd0";
-  sha256 = "sha256-/ntSVJ+HfdM6mHKYwR6zijClkBP0eZg7oVZL6/QqNMo=";
+  rev = "1d60b20db08f9262427159da51d02b5523085247";
+  sha256 = "sha256-Cpkq/6lfMh1+VAh1woTbuC+7fVlSXUsH0gx02yWb6j8=";
 }

--- a/pkgs/sway-unwrapped/metadata.nix
+++ b/pkgs/sway-unwrapped/metadata.nix
@@ -5,6 +5,6 @@ rec {
   repo = "sway";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "28fd73589df0e73e1d15e165acd90651a5f805d6";
-  sha256 = "sha256-hdVdBJiPyIJLH71iFf1cNInu94YSOc24ZCKedMEy3NM=";
+  rev = "9bb45a403758c8606fe9a7f0b5b5316bae1a12dd";
+  sha256 = "sha256-gcdAZLZ1hqqMjnHEnGpV/YGkTKVTyfyL+zsfDyEpBsQ=";
 }

--- a/pkgs/waybar/metadata.nix
+++ b/pkgs/waybar/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "Waybar";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "b26ab1f982c06ce48e96f3e4da8cde034296eb1d";
-  sha256 = "sha256-isr9Ht+QRuj89/0frJBEGVvm7A3yy0ml3jj57wGmiXM=";
+  rev = "003dd3a9a260a212648b6ab4a70f058c6437d40d";
+  sha256 = "sha256-BwBRNmGv2nX1nEhitOKyoOvmk+G6WoBaBHAlKYy5Edg=";
 }

--- a/pkgs/wayvnc/metadata.nix
+++ b/pkgs/wayvnc/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "wayvnc";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "2d62e1203e5589cf754e9b7031ddc609124cf156";
-  sha256 = "sha256-dxJOTorjR/gSi/S7cs3b4eGEdnMqgOLYL2Li6Dv1pn4=";
+  rev = "e64e95c1c2cc83f0f08f1b00cde48c92bf40cc32";
+  sha256 = "sha256-+3r/6JkQrhCtK8OI6mX8SnvxKr12MNaRA+arBZNiCQU=";
 }

--- a/pkgs/wbg/metadata.nix
+++ b/pkgs/wbg/metadata.nix
@@ -5,6 +5,6 @@ rec {
   repo = "wbg";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "5fbfd76293e7ce2d189e6742f0a957e538d76036";
-  sha256 = "sha256-2fEcngrN3EC5ecnIkrrQJYHhVLL1j5eKg8oHy25EUg4=";
+  rev = "74ecbee9035b71c685413e99eae3798c858a2a83";
+  sha256 = "sha256-N0iy1DllsMjFVZwTL9fPjcbs1VSCBYNva5yqcqAt8RA=";
 }

--- a/pkgs/wlroots/metadata.nix
+++ b/pkgs/wlroots/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "wlroots";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "0a79bc28c7ebd4d3060f92dfd8893c6b981239e8";
-  sha256 = "sha256-GYlJXp6dFQgjJXc+T2Fs+1i7yuQjf5IM1+BWn+ivBOg=";
+  rev = "7e13dfdd4dd3e2a1c2c671ba9709c77a9eb045b2";
+  sha256 = "sha256-jPbtZb+Q7LCKVp4+ve2egjnjP1uR+a5cElvYhBgm0Ic=";
 }


### PR DESCRIPTION
For some reason there's some weird dependency ordering. `wlroots` needs to be updated before `waybar`.

So, I did that locally, pushing to unblock updates.