### PR TITLE
tree: react to wayland-scanner changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -219,6 +219,20 @@
               attrName = "new-wayland-protocols";
               nixpkgsAttrName = "wayland-protocols";
             }
+            {
+              attrName = "swayidle";
+              nixpkgsAttrName = "swayidle";
+              extra.nativeBuildInputs = [ prev.wayland-scanner ];
+              # TODO: this shouldn't be needed, but is:
+              extra.buildInputs = [ prev.wayland-scanner ];
+            }
+            {
+              attrName = "swaylock-effects";
+              nixpkgsAttrName = "swaylock-effects";
+              extra.nativeBuildInputs = [ prev.wayland-scanner ];
+              # TODO: this shouldn't be needed, but is:
+              extra.buildInputs = [ prev.wayland-scanner ];
+            }
             # {
             #   attrName = "wl-screenrec";
             #   # soon in nixpkgs
@@ -266,8 +280,6 @@
                 "neatvnc"
                 "slurp"
                 "swaybg"
-                "swayidle"
-                "swaylock-effects"
                 "wl-clipboard"
                 "wlogout"
                 "wlr-randr"

--- a/pkgs/gtk-layer-shell/metadata.nix
+++ b/pkgs/gtk-layer-shell/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "gtk-layer-shell";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "5f71546112fd284aced13e7b2391a601204bcacd";
-  sha256 = "sha256-U8DibB4v87LJAUw8YMjPzHi5/1so0wdiiZGRnNX0yJw=";
+  rev = "f05fe793d3ba5c0241d82902ac95fc9dc992bc5b";
+  sha256 = "sha256-crfK7N0E0MWf1Gew9USmW2pcKi75/yZ9TSYC4h+PzNQ=";
 }

--- a/pkgs/wayprompt/default.nix
+++ b/pkgs/wayprompt/default.nix
@@ -9,6 +9,7 @@
   scdoc,
   wayland,
   wayland-protocols,
+  wayland-scanner,
   zig,
 }:
 
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
     pkg-config
     scdoc
     wayland
-    # wayland-scanner
+    wayland-scanner
   ];
   buildInputs = [
     fcft

--- a/pkgs/wlvncc/default.nix
+++ b/pkgs/wlvncc/default.nix
@@ -7,6 +7,7 @@
   ninja,
   wayland,
   wayland-protocols,
+  wayland-scanner,
   libxkbcommon,
   libvncserver,
   libpthreadstubs,
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
+    wayland-scanner
     meson
     ninja
   ];


### PR DESCRIPTION
cc: @Artturin 

I don't understand why swayidle/swaylock-effects seems to want `wayland-scanner` in `buildInputs`. It doesn't work for me if I only list it in `nativeBuildInputs` ?