### PR TITLE
Fix waybar

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,17 +80,8 @@
             }
             {
               attrName = "waybar";
-              extra.buildInputs = [
-                prev.libjack2
-                prev.playerctl
-                prev.upower
-              ];
               replace = previousAttrs: {
-                patches = lib.remove (lib.elemAt previousAttrs.patches 0) previousAttrs.patches;
-                buildInputs = (lib.remove (lib.elemAt previousAttrs.buildInputs 27) previousAttrs.buildInputs) ++ [
-                  prev.wireplumber
-                ];
-                mesonFlags = lib.remove "-Dgtk-layer-shell=enabled" prev.waybar.mesonFlags;
+                patches = [];
                 postUnpack =
                   let
                     # Derived from subprojects/cava.wrap

--- a/flake.nix
+++ b/flake.nix
@@ -86,22 +86,22 @@
                   let
                     # Derived from subprojects/cava.wrap
                     libcava = rec {
-                      version = "0.10.2";
+                      version = "0.10.3";
                       src = prev.fetchFromGitHub {
                         owner = "LukashonakV";
                         repo = "cava";
                         rev = version;
-                        hash = "sha256-jU7RQV2txruu/nUUl0TzjK4nai7G38J1rcTjO7UXumY=";
+                        hash = "sha256-ZDFbI69ECsUTjbhlw2kHRufZbQMu+FQSMmncCJ5pagg=";
                       };
                     };
                     # Derived from subprojects/catch2.wrap
                     catch2 = rec {
-                      version = "3.5.1";
+                      version = "3.7.0";
                       src = prev.fetchFromGitHub {
                         owner = "catchorg";
                         repo = "Catch2";
                         rev = "v${version}";
-                        hash = "sha256-OyYNUfnu6h1+MfCF8O+awQ4Usad0qrdCtdZhYgOY+Vw=";
+                        hash = "sha256-U9hv6DaqN5eCMcAQdfFPqWpsbqDFxRQixELSGbNlc0g=";
                       };
                     };
                   in

--- a/pkgs/waybar/metadata.nix
+++ b/pkgs/waybar/metadata.nix
@@ -4,6 +4,6 @@ rec {
   repo = "Waybar";
   repo_git = "https://${domain}/${owner}/${repo}";
   branch = "master";
-  rev = "cad18f39f51fdbd93d3236572c8f18728b3a0930";
-  sha256 = "sha256-dt95fNEHaXBOvEtvaBpv1KsLhwWVulX4ndrVL7LPuZE=";
+  rev = "280f11e247bc264541bb7daa01ffcce9fe6721a1";
+  sha256 = "sha256-m1KNJf5HkY9myhtNMhgd2XZGJ2lqWMD1jDi4NgDCfoQ=";
 }


### PR DESCRIPTION
the waybar build is currently broken when advancing (see [actions/advance](https://github.com/nix-community/nixpkgs-wayland/actions/runs/11191869115/job/31115317900))

the [fix attempt](https://github.com/nix-community/nixpkgs-wayland/commit/a40e6b047b6166aed5fab801e99a8d6b980d4680) by @Artturin was unsuccessful.

i tested the following:
- build `cad18f39` with just the fix
- build `280f11e2` with just the fix
- build `280f11e2` with updated nixpkgs (not contained in this MR)

for some context:
- `libjack2`, `playerctl` and `upower` are already defined buildinputs in nixpkgs
- the whole  `(lib.remove (lib.elemAt previousAttrs.buildInputs 27)` thing effectively removed `upower`, as the length and order of the buildinputs has long changed in nixpkgs

cc @Artturin 